### PR TITLE
Use delete rather than array subtraction

### DIFF
--- a/mygame/lib/wfc/simple_tiled_model.rb
+++ b/mygame/lib/wfc/simple_tiled_model.rb
@@ -100,7 +100,7 @@ module Wfc
 
     def process_starting_cell(cell)
       cell.collapse
-      @uncollapsed_cells_grid -= [cell]
+      @uncollapsed_cells_grid.delete(cell)
       return if @uncollapsed_cells_grid.empty?
 
       propagate(cell)


### PR DESCRIPTION
Using delete is over 200% slower.

```
- 000129 [Game] -> args.gtk.benchmark iterations: 10000, using_delete: -> { array1.delete(500) }, using_minus: -> { array2 -= [500] }
- 000130 [Game] 
* BENCHMARK WINNER: using_delete
** Caller:     
** Iterations: 10_000
** Fastest:    using_delete
** Second:     using_minus
** Margin %:   using_minus was 207% slower than using_delete
** Margin ms:  using_minus took 349ms longer than using_delete (169ms vs 518ms)
** Times:
*** using_delete: total: 169ms, perc: 0% slower, diff: 0ms.
*** using_minus: total: 518ms, perc: 207% slower, diff: 349ms.
```